### PR TITLE
Strip trailing dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Docs.rs badge](https://docs.rs/bad_email/badge.svg)
 
-This crate can be used to check email domains against a list of 10235 known [disposable email domains](http://en.wikipedia.org/wiki/Disposable_email_address). 
+This crate can be used to check email domains against a list of 10234 known [disposable email domains](http://en.wikipedia.org/wiki/Disposable_email_address). 
 
 The crate has one function that returns true or false based on a full email being passed in as a copy of str slice and then splinting the str on '@' and then comparing the domain name to the list of unwanted domain names. 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Docs.rs badge](https://docs.rs/bad_email/badge.svg)
 
-This crate can be used to check email domains against a list of 10234 known [disposable email domains](http://en.wikipedia.org/wiki/Disposable_email_address). 
+This crate can be used to check email domains against a list of 10234 known [disposable email domains](http://en.wikipedia.org/wiki/Disposable_email_address). <!-- The first line of the file has no domain, so it doesn't count. @SpellignErr 03Mar2024 -->
 
 The crate has one function that returns true or false based on a full email being passed in as a copy of str slice and then splinting the str on '@' and then comparing the domain name to the list of unwanted domain names. 
 

--- a/src/domain_checker.rs
+++ b/src/domain_checker.rs
@@ -44,7 +44,13 @@ pub fn is_email_unwanted(email_address: &str) -> bool {
 }
 
 pub fn extract_domain(email_address: &str) -> Option<&str> {
-  email_address.split('@').nth(1)
+  // Remove trailing dot from email address domain. Domains all end in a literal dot (period) character
+  // therefore john@example.com is identical to john@example.com.
+  // This new code will remove te trailing dot. See RFC1034 and subsequent updates for more info
+  // https://datatracker.ietf.org/doc/html/rfc1034
+  //
+  // @SpellignErr 03Mar2024
+  email_address.strip_suffix(".").unwrap_or(email_address).split('@').nth(1)
 }
 
 // Functions - End


### PR DESCRIPTION
Strip tailing dot from input email address and update remadme to contain the correct amount of domains. See RFC 1034 for info regarding domain trailing dot